### PR TITLE
Add Redis plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 coverage
+.nyc_output

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,127 @@
+***This is a work in progress.***
+
+# Redis plugin
+
+The Redis plugin holds context data in the Redis.
+
+## Pre-requisite
+
+To run this you need a Redis server running. For details see <a href="http://redis.io/" target="_new">the Redis site</a>.
+
+## Install
+
+1. Run the following command in your Node-RED user directory - typically `~/.node-red`
+
+    npm install git+https://github.com/node-red/node-red-context-redis
+
+1. Add a configuration in settings.js:
+
+```javascript
+contextStorage: {
+    redis: {
+        module: require("node-red-context-redis"),
+        config: {
+            // see below options
+        }
+    }
+}
+```
+
+### Options
+
+This plugin exposes some options defined in [node_redis](https://github.com/NodeRedis/node_redis) as itself options.
+It needs following configuration options:
+
+| Options  | Description                                                                                                 |
+| -------- | ----------------------------------------------------------------------------------------------------------- |
+| host     | The IP address of the Redis server.    `Default: "127.0.0.1"`                                               |
+| port     | The port of the Redis server.          `Default: 6379`                                                      |
+| db       | The Redis logical database to connect. `Default: 0`                                                         |
+| prefix   | If set, the string used to prefix all used keys.                                                            |
+| password | If set, the plugin will run Redis AUTH command on connect. *Note: the password will be sent as plaintext.*  |
+| tls      | An object containing options to pass to tls.connect to set up a TLS connection to the server.               |
+
+see https://github.com/NodeRedis/node_redis#options-object-properties
+
+## Data Model
+
+```text
+Node-RED                      Redis
++-------------------+         +-------------------------------+
+| global context    |         | logical database              |
+| +---------------+ |         | +---------------------------+ |
+| | +-----+-----+ | |         | | +-----------------+-----+ | |
+| | | key |value| | | <-----> | | | global:key      |value| | |
+| | +-----+-----+ | |         | | +-----------------+-----+ | |
+| +---------------+ |         | |                           | |
+|                   |         | |                           | |
+| flow context      |         | |                           | |
+| +---------------+ |         | |                           | |
+| | +-----+-----+ | |         | | +-----------------+-----+ | |
+| | | key |value| | | <-----> | | | <flow's id>:key |value| | |
+| | +-----+-----+ | |         | | +-----------------+-----+ | |
+| +---------------+ |         | |                           | |
+|                   |         | |                           | |
+| node context      |         | |                           | |
+| +---------------+ |         | |                           | |
+| | +-----+-----+ | |         | | +-----------------+-----+ | |
+| | | key |value| | | <-----> | | | <node's id>:key |value| | |
+| | +-----+-----+ | |         | | +-----------------+-----+ | |
+| +---------------+ |         | +---------------------------+ |
++-------------------+         +-------------------------------+
+```
+
+- This plugin uses a Redis logical database for all context scope.
+- This plugin prefixes all used keys with context scope in order to identify the scope of the key.
+  - The keys of `global context` will be prefixed with `global:` .
+    e.g.  Set `"foo"` to hold `"bar"` in the global context -> Set `"global:foo"` to hold `"bar"` in the Redis logical database.
+  - The keys of `flow context` will be prefixed with `<id of the flow>:` .
+    e.g.  Set `"foo"` to hold `"bar"` in the flow context whose id is `8588e4b8.784b38` -> Set `"8588e4b8.784b38:foo"` to hold `"bar"` in the Redis.
+  - The keys of `node context` will be prefixed with `<id of the node>:` .
+    e.g.  Set `"foo"` to hold `"bar"` in the node context whose id is `80d8039e.2b82:8588e4b8.784b38` -> Set `"80d8039e.2b82:8588e4b8.784b38:foo"` to hold `"bar"` in the Redis.
+
+## Data Structure
+
+- This plugin converts a value of context to JSON and stores it as string type to the Redis.
+- After getting a value from the Redis, the plugin also converts the value to an object or a primitive value.
+
+```text
+Node-RED                                 Redis
++------------------------------+         +---------------------------------------------+
+| global context               |         | logical database                            |
+| +--------------------------+ |         | +-----------------------------------------+ |
+| | +--------+-------------+ | |         | | +---------------+---------------------+ | |
+| | | str    | "foo"       | | | <-----> | | | global:str    | "\"foo\""           | | |
+| | +--------+-------------+ | |         | | +---------------+---------------------+ | |
+| | | num    | 1           | | | <-----> | | | global:num    | "1"                 | | |
+| | +--------+-------------+ | |         | | +---------------+---------------------+ | |
+| | | nstr   | "10"        | | | <-----> | | | global:nstr   | "\"10\""            | | |
+| | +--------+-------------+ | |         | | +---------------+---------------------+ | |
+| | | bool   | false       | | | <-----> | | | global:bool   | "false"             | | |
+| | +--------+-------------+ | |         | | +---------------+---------------------+ | |
+| | | arr    | ["a","b"]   | | | <-----> | | | global:arr    | "[\"a\",\"b\"]"     | | |
+| | +--------+-------------+ | |         | | +---------------+---------------------+ | |
+| | | obj    | {foo,"bar"} | | | <-----> | | | global:obj    | "{\"foo\",\"bar\"}" | | |
+| | +--------+-------------+ | |         | | +---------------+---------------------+ | |
+| +--------------------------+ |         | +-----------------------------------------+ |
++------------------------------+         +---------------------------------------------+
+```
+
+Other Redis client(e.g. redis-cli) can get the value stored by Node-RED like followings.
+
+Node-RED
+
+```javascript
+global.set("foo","bar","redis");
+global.set("obj",{key:"value"},"redis");
+```
+
+redis-cli
+
+```console
+redis> GET global:foo
+"\"var\""
+redis> GET global:obj
+"{\"key\":\"value\"}"
+redis>
+```

--- a/Readme.md
+++ b/Readme.md
@@ -32,14 +32,16 @@ contextStorage: {
 This plugin exposes some options defined in [node_redis](https://github.com/NodeRedis/node_redis) as itself options.
 It needs following configuration options:
 
-| Options  | Description                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| host     | The IP address of the Redis server.    `Default: "127.0.0.1"`                                               |
-| port     | The port of the Redis server.          `Default: 6379`                                                      |
-| db       | The Redis logical database to connect. `Default: 0`                                                         |
-| prefix   | If set, the string used to prefix all used keys.                                                            |
-| password | If set, the plugin will run Redis AUTH command on connect. *Note: the password will be sent as plaintext.*  |
-| tls      | An object containing options to pass to tls.connect to set up a TLS connection to the server.               |
+| Options        | Description                                                                                                 |
+| -------------- | ----------------------------------------------------------------------------------------------------------- |
+| host           | The IP address of the Redis server.    `Default: "127.0.0.1"`                                               |
+| port           | The port of the Redis server.          `Default: 6379`                                                      |
+| db             | The Redis logical database to connect. `Default: 0`                                                         |
+| prefix         | If set, the string used to prefix all used keys.                                                            |
+| password       | If set, the plugin will run Redis AUTH command on connect. *Note: the password will be sent as plaintext.*  |
+| tls            | An object containing options to pass to tls.connect to set up a TLS connection to the server.               |
+| retry_strategy | Specifies a function to reconnect if the connection to Redis is lost.                                       |
+|                | `default: undefined (Use the default retry strategy)`                                                       |
 
 see https://github.com/NodeRedis/node_redis#options-object-properties
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@
  *                             // default: undefined
  *    tls:                     // An object containing options to pass to tls.connect to set up a TLS connection to Redis
  *                             // default: undefined
+ *    retry_strategy:          // Specifies a function to reconnect if the connection to Redis is lost.
+ *                             // default: undefined (Use the default retry strategy)
  *  }
  *
  * This plugin prefixes all used keys with context scope.
@@ -175,8 +177,7 @@ function Redis(config) {
         db: config.db || 0,
         password: config.password,
         tls: config.tls,
-        //Do not try to reconnect, throw an error
-        retry_strategy: () => undefined
+        retry_strategy: config.retry_strategy || undefined
     };
     this.client = null;
     this.knownCircularRefs = {};

--- a/index.js
+++ b/index.js
@@ -399,34 +399,34 @@ Redis.prototype.delete = function (scope) {
 
 Redis.prototype.clean = function (_activeNodes) {
     this.knownCircularRefs = {};
-    // TODO: How to determine the data that no one is using
-    // return new Promise((resolve, reject) => {
-    //     this.client.KEYS((this.options.prefix || '') + '*', (err, res) => {
-    //         if (err) {
-    //             reject(err);
-    //         } else {
-    //             if(this.options.prefix){
-    //                 res = res.map(key => key.substring(this.options.prefix.length))
-    //             }
-    //             res = res.filter(key => !key.startsWith("global"))
-    //             _activeNodes.forEach(scope => {
-    //                 res = res.filter(key => !key.startsWith(scope))
-    //             })
-    //             if (res.length > 0) {
-    //                 this.client.DEL(...res, (err) => {
-    //                     if (err) {
-    //                         reject(err);
-    //                     } else {
-    //                         resolve();
-    //                     }
-    //                 });
-    //             } else {
-    //                 resolve()
-    //             }
-    //         }
-    //     });
-    // });
-    return Promise.resolve();
+     return new Promise((resolve, reject) => {
+        this.client.KEYS((this.prefix || '') + '*', (err, res) => {
+            if (err) {
+                reject(err);
+            } else {
+                if(this.prefix){
+                    res = res.map(key => key.substring(this.prefix.length + 1))
+                }
+                res = res.filter(key => !key.startsWith("global"))
+                _activeNodes.forEach(scope => {
+                    res = res.filter(key => !key.startsWith(scope))
+                })
+                var remove = [];
+                res.forEach(key => remove.push(this.prefix + ":" + key));
+                if (remove.length > 0) {
+                    this.client.DEL(...remove, (err) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve();
+                        }
+                    });
+                } else {
+                    resolve()
+                }
+            }
+        });
+    });
 };
 
 module.exports = function (config) {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,434 @@
+/**
+ * Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+/**
+ * Redis based context storage
+ *
+ * Configuration options:
+ * {
+ *    home: '127.0.0.1',       // The IP address of the Redis server
+ *                             // default: '127.0.0.1'
+ *    port: 6379,              // The port of the Redis server
+ *                             // default: 6379
+ *    db: 0                    // The Redis logical database to connect
+ *                             // default: 0
+ *    prefix:                  // The string used to prefix all used keys
+ *                             // If set, the plugin uses 'prefix + scope + keyname' as key
+ *                             // (e.g. prefix:'foo', global.get('key') -> GET foo:global:key )
+ *                             // default: undefined
+ *    password:                // If set, the plugin will run Redis AUTH command on connect
+ *                             // Note: the password will be sent as plaintext
+ *                             // default: undefined
+ *    tls:                     // An object containing options to pass to tls.connect to set up a TLS connection to Redis
+ *                             // default: undefined
+ *  }
+ *
+ * This plugin prefixes all used keys with context scope.
+ * For example
+ *   context.get('foo') ->  The plugin will get the value of '<id of Node>:foo' (e.g. '36b85111.47f5fe:5b17c82f.6a0888:foo')
+ *   flow.get('foo')    ->  The plugin will get the value of '<id of Flow>:foo' (e.g. '5b17c82f.6a0888:foo')
+ *   global.get('foo')  ->  The plugin will get the value of 'global:foo'
+ *
+ * If 'prefix' in above options is set, the key will be prefixed with it additionally.
+ */
+
+const redis = require('redis');
+// Require @node-red/util loaded in the Node-RED runtime.
+const util = process.env.NODE_RED_HOME ?
+    require(require.resolve('@node-red/util', { paths: [process.env.NODE_RED_HOME] })).util :
+    require('@node-red/util').util;
+const log = process.env.NODE_RED_HOME ?
+    require(require.resolve('@node-red/util', { paths: [process.env.NODE_RED_HOME] })).log :
+    require('@node-red/util').log;
+
+const safeJSONStringify = require('json-stringify-safe');
+
+// This lua script sets a nested property to JSON atomically
+// Usage: EVALSHA(SHA, 1, key, property, [property...], JSON)
+// e.g. Set obj.a.b.c to {foo: 'bar'} -> EVALSHA(SHA, 1, 'obj', 'a', 'b', 'c', '{"foo":"bar"}');
+const setScript = `
+    -- get the value of key
+    local data = redis.call('GET', KEYS[1]);
+    if data then
+        data = cjson.decode(data);
+    else
+        data = {}
+    end
+    -- parse path
+    local path = data;
+    local next;
+    for i = 1, #ARGV-1 do
+        next = tonumber(ARGV[i]);
+        if next then
+            next = next + 1;
+        else
+            next = ARGV[i]
+        end
+        if i == #ARGV-1 then
+            break;
+        end
+        if not path[next] then
+            path[next] = {};
+        end
+        path = path[next];
+    end
+    path[next] = cjson.decode(ARGV[#ARGV]);
+    -- convert and set the value
+    return redis.call('SET', KEYS[1], cjson.encode(data));
+`;
+
+// This lua script deletes a nested property atomically
+// Usage: EVALSHA(SHA, 1, key, property, [property...]);
+// e.g. Delete obj.a.b.c -> EVALSHA(SHA, 1, 'obj', 'a', 'b', 'c');
+const deleteScript = `
+    -- get the value of key
+    local data = redis.call('GET', KEYS[1]);
+    if data then
+        data = cjson.decode(data);
+    end
+    -- parse path
+    local path = data;
+    local next = tonumber(ARGV[1]);
+    for i = 2, #ARGV do
+        if not path then
+            return 0;
+        end
+        if next then
+            path = path[next+1];
+        else
+            path = path[ARGV[i-1]];
+        end
+        next = tonumber(ARGV[i]);
+    end
+    -- delete the property
+    if next and path[next+1] then
+        table.remove(path, next+1);
+    elseif path[ARGV[#ARGV]] then
+        path[ARGV[#ARGV]] = nil;
+    else
+    -- return if try to delete non-existent value
+        return 0
+    end
+    -- convert and set the value
+    return redis.call('SET', KEYS[1], cjson.encode(data));
+`;
+
+function stringify(value) {
+    let hasCircular;
+    let result = safeJSONStringify(value, null, null, function (k, v) { hasCircular = true; });
+    return { json: result, circular: hasCircular };
+}
+
+function addPrefix(prefix, scope, key) {
+    if (prefix) {
+        scope = prefix + ':' + scope;
+    }
+    return scope + ':' + key;
+}
+
+function removePrefix(prefix, scope, key) {
+    if (prefix) {
+        key = key.substring((prefix + ':').length);
+    }
+    return key.substring((scope + ':').length);
+}
+
+function scan(client, pattern, cursor = 0) {
+    return new Promise((resolve, reject) => {
+        client.SCAN(cursor, 'MATCH', pattern, 'COUNT', 1000, (err, results) => {
+            if (err) {
+                return reject(err);
+            } else {
+                const cursor = results[0];
+                const elements = results[1];
+                if (cursor === "0") {
+                    //the iteration finished
+                    resolve(elements);
+                } else {
+                    scan(client, pattern, cursor).then(result => {
+                        resolve(elements.concat(result));
+                    });
+                }
+            }
+        });
+    });
+}
+
+function Redis(config) {
+    this.host = config.host || '127.0.0.1';
+    this.port = config.port || 6379;
+    this.prefix = config.prefix;
+    this.options = {
+        db: config.db || 0,
+        password: config.password,
+        tls: config.tls,
+        //Do not try to reconnect, throw an error
+        retry_strategy: () => undefined
+    };
+    this.client = null;
+    this.knownCircularRefs = {};
+}
+
+Redis.prototype.open = function () {
+    const promises = [];
+    this.client = redis.createClient(this.port, this.host, this.options);
+    this.client.on('error', function (err) {
+        log.error(err);
+    });
+    promises.push(new Promise((resolve, reject) => {
+        // Load the script into the scripts cache of Redis
+        this.client.SCRIPT('load', setScript, (err, res) => {
+            if (err) {
+                reject(err.origin || err);
+            } else {
+                this.setSHA = res;
+                resolve();
+            }
+        });
+    }));
+    promises.push(new Promise((resolve, reject) => {
+        // Load the script into the scripts cache of Redis
+        this.client.SCRIPT('load', deleteScript, (err, res) => {
+            if (err) {
+                reject(err.origin || err);
+            } else {
+                this.deleteSHA = res;
+                resolve();
+            }
+        });
+    }));
+    return Promise.all(promises);
+};
+
+Redis.prototype.close = function () {
+    return new Promise((resolve, reject) => {
+        this.client.QUIT((err) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve();
+            }
+        });
+    });
+};
+
+Redis.prototype.get = function (scope, key, callback) {
+    if (typeof callback !== 'function') {
+        throw new Error('Callback must be a function');
+    }
+    try {
+        if (!Array.isArray(key)) {
+            key = [key];
+        }
+        const mgetArgs = [];
+        // Filter duplicate keys in order to reduce response data
+        const rootKeys = key.map(key => util.normalisePropertyExpression(key)[0]).filter((key, index, self) => self.indexOf(key) === index);
+        rootKeys.forEach(key => mgetArgs.push(addPrefix(this.prefix, scope, key)));
+        this.client.MGET(...mgetArgs, (err, replies) => {
+            if (err) {
+                callback(err);
+            } else {
+                let results = [];
+                let data = {};
+                let value;
+                for (let i = 0; i < rootKeys.length; i++) {
+                    try {
+                        if (replies[i]) {
+                            data[rootKeys[i]] = JSON.parse(replies[i]);
+                        }
+                    } catch (err) {
+                        // If data is not JSON, return `undefined`
+                        break;
+                    }
+                }
+                for (let i = 0; i < key.length; i++) {
+                    try {
+                        value = util.getObjectProperty(data, key[i]);
+                    } catch (err) {
+                        if (err.code === 'INVALID_EXPR') {
+                            throw err;
+                        }
+                        value = undefined;
+                    }
+                    results.push(value);
+                }
+                callback(null, ...results);
+            }
+        });
+    } catch (err) {
+        callback(err);
+        return;
+    }
+};
+
+Redis.prototype.set = function (scope, key, value, callback) {
+    if (callback && typeof callback !== 'function') {
+        throw new Error('Callback must be a function');
+    }
+    try {
+        if (!Array.isArray(key)) {
+            key = [key];
+            value = [value];
+        } else if (!Array.isArray(value)) {
+            // key is an array, but value is not - wrap it as an array
+            value = [value];
+        }
+        const multi = this.client.MULTI();
+        let msetArgs = [];
+        let delArgs = [];
+        // parse key
+        const keyParts = key.map(key => util.normalisePropertyExpression(key));
+
+        for (let i = 0; i < key.length; i++) {
+            if (i >= value.length) {
+                value[i] = null;
+            }
+            keyParts[i][0] = addPrefix(this.prefix, scope, keyParts[i][0]);
+
+            if (value[i] !== undefined) { // set a value
+                const stringifiedContext = stringify(value[i]);
+
+                if (stringifiedContext.circular && !this.knownCircularRefs[keyParts[i][0]]) {
+                    log.warn(log._('context.localfilesystem.error-circular', { scope: keyParts[i][0] }));
+                    this.knownCircularRefs[keyParts[i][0]] = true;
+                } else {
+                    delete this.knownCircularRefs[keyParts[i][0]];
+                }
+
+                if (delArgs.length > 0) {
+                    // Queue a command in order to execute commands sequentially
+                    multi.DEL(...delArgs);
+                    delArgs = [];
+                }
+                if (keyParts[i].length === 1) {
+                    msetArgs.push(keyParts[i][0], stringifiedContext.json);
+                } else {
+                    if (msetArgs.length > 0) {
+                        multi.MSET(...msetArgs);
+                        msetArgs = [];
+                    }
+                    // To set a nested property atomically, call the lua script
+                    multi.EVALSHA(this.setSHA, 1, ...keyParts[i], stringifiedContext.json);
+                }
+            } else { // delete a value
+                delete this.knownCircularRefs[keyParts[i][0]];
+
+                if (msetArgs.length > 0) {
+                    // Queue a command in order to execute commands sequentially
+                    multi.MSET(...msetArgs);
+                    msetArgs = [];
+                }
+                if (keyParts[i].length === 1) {
+                    delArgs.push(keyParts[i][0]);
+                } else {
+                    if (delArgs.length > 0) {
+                        multi.DEL(...delArgs);
+                        delArgs = [];
+                    }
+                    // To delete a nested property atomically, call the lua script
+                    multi.EVALSHA(this.deleteSHA, 1, ...keyParts[i]);
+                }
+            }
+        }
+        if (msetArgs.length > 0) {
+            multi.MSET(...msetArgs);
+        }
+        if (delArgs.length > 0) {
+            multi.DEL(...delArgs);
+        }
+        // Execute commands at once with transactions
+        multi.EXEC((err, replies) => {
+            if (err) {
+                if (callback) {
+                    callback(err);
+                }
+            } else {
+                if (callback) {
+                    callback(null);
+                }
+            }
+        });
+    } catch (err) {
+        if (callback) {
+            callback(err);
+        }
+    }
+};
+
+Redis.prototype.keys = function (scope, callback) {
+    if (typeof callback !== 'function') {
+        throw new Error('Callback must be a function');
+    }
+    scan(this.client, addPrefix(this.prefix, scope, '*')).then(result => {
+        callback(null, result.map(v => removePrefix(this.prefix, scope, v)));
+    }).catch(err => {
+        callback(err);
+    });
+};
+
+Redis.prototype.delete = function (scope) {
+    return scan(this.client, addPrefix(this.prefix, scope, '*')).then(result => {
+        if (result.length === 0) {
+            return;
+        } else {
+            return new Promise((resolve, reject) => {
+                this.client.DEL(...result, err => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                });
+            });
+        }
+    });
+};
+
+Redis.prototype.clean = function (_activeNodes) {
+    this.knownCircularRefs = {};
+    // TODO: How to determine the data that no one is using
+    // return new Promise((resolve, reject) => {
+    //     this.client.KEYS((this.options.prefix || '') + '*', (err, res) => {
+    //         if (err) {
+    //             reject(err);
+    //         } else {
+    //             if(this.options.prefix){
+    //                 res = res.map(key => key.substring(this.options.prefix.length))
+    //             }
+    //             res = res.filter(key => !key.startsWith("global"))
+    //             _activeNodes.forEach(scope => {
+    //                 res = res.filter(key => !key.startsWith(scope))
+    //             })
+    //             if (res.length > 0) {
+    //                 this.client.DEL(...res, (err) => {
+    //                     if (err) {
+    //                         reject(err);
+    //                     } else {
+    //                         resolve();
+    //                     }
+    //                 });
+    //             } else {
+    //                 resolve()
+    //             }
+    //         }
+    //     });
+    // });
+    return Promise.resolve();
+};
+
+module.exports = function (config) {
+    return new Redis(config);
+};

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
  *
  * Configuration options:
  * {
- *    home: '127.0.0.1',       // The IP address of the Redis server
+ *    host: '127.0.0.1',       // The IP address of the Redis server
  *                             // default: '127.0.0.1'
  *    port: 6379,              // The port of the Redis server
  *                             // default: 6379

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "node-red-context-redis",
+  "version": "0.0.1",
+  "description": "A Node-RED Context store plugin backed by Redis",
+  "main": "index.js",
+  "scripts": {
+    "test": "nyc --cache mocha ./test/_spec.js --timeout=8000",
+    "coverage": "nyc report --reporter=lcov --reporter=html"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/node-red/node-red-context-redis.git"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@node-red/util": "0.20.0-beta.2",
+    "json-stringify-safe": "^5.0.1",
+    "redis": "^2.8.0"
+  },
+  "devDependencies": {
+    "mocha": "^5.2.0",
+    "nyc": "^10.0.0",
+    "should": "^13.2.1",
+    "should-sinon": "0.0.6",
+    "sinon": "^7.2.2"
+  },
+  "keywords": [
+    "node-red",
+    "redis"
+  ],
+  "engines": {
+    "node": ">=8"
+  }
+}

--- a/test/_spec.js
+++ b/test/_spec.js
@@ -62,7 +62,7 @@ describe('redis', function () {
             });
         });
         it('should throw an error if cannot connect to redis', function () {
-            const context = redisPlugin({ host: "foobar" });
+            const context = redisPlugin({ host: "foobar", retry_strategy: () => undefined });
             return context.open().should.be.rejected();
         });
     });
@@ -577,7 +577,7 @@ describe('redis', function () {
         });
     });
 
-    describe.skip('#clean', function () {
+    describe('#clean', function () {
         const prefix = util.generateId();
         const context = redisPlugin({ prefix: prefix });
         function redisGet(scope, key) {

--- a/test/_spec.js
+++ b/test/_spec.js
@@ -1,0 +1,621 @@
+/**
+ * Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+const sinon = require('sinon');
+const should = require('should');
+require('should-sinon');
+const redis = require('redis');
+const util = require("@node-red/util").util;
+const redisPlugin = require('../index.js');
+
+describe('redis', function () {
+    before(function () {
+        const self = this;
+        const context = redisPlugin({});
+        return context.open().then(() => {
+            return context.close();
+        }).catch(() => {
+            // If you can not connect to Redis(127.0.0.1:6379), all tests will be skipped.
+            self.test.parent.pending = true;
+            self.skip();
+        });
+    });
+
+    describe('#open', function () {
+        it('should connect to redis', function () {
+            const context = redisPlugin({});
+            return context.open().then(() => {
+                context.client.connected.should.be.true();
+                return context.close();
+            });
+
+        });
+        it('should load configs', function () {
+            const fakeCreateClient = function () {
+                return {
+                    SCRIPT: (a, b, cb) => cb(null),
+                    on: () => { }
+                };
+            };
+            const stubCreateClient = sinon.stub(redis, "createClient").callsFake(fakeCreateClient);
+            const context = redisPlugin({ host: "foo", port: 12345, db: 1, prefix: "bar", password: "baz", tls: { a: "b" } });
+            return context.open().then(function () {
+                context.should.have.properties({ host: "foo", port: 12345, prefix: "bar" });
+                context.options.should.have.properties({ db: 1, password: "baz", tls: { a: "b" } });
+                stubCreateClient.should.be.calledWithMatch(12345, "foo", { db: 1, password: "baz", tls: { a: "b" } });
+            }).finally(() => {
+                stubCreateClient.restore();
+            });
+        });
+        it('should throw an error if cannot connect to redis', function () {
+            const context = redisPlugin({ host: "foobar" });
+            return context.open().should.be.rejected();
+        });
+    });
+
+    describe('#get/set', function () {
+        const prefix = util.generateId();
+        const context = redisPlugin({ prefix: prefix });
+
+        before(function () {
+            return context.open();
+        });
+        afterEach(function () {
+            return context.delete("*").then(() => context.clean([]));
+        });
+        after(function () {
+            return context.close();
+        });
+
+        it('should store property', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                if (err) { return done(err); }
+                should.not.exist(value);
+                context.set("nodeX", "foo", "test", function (err) {
+                    if (err) { return done(err); }
+                    context.get("nodeX", "foo", function (err, value) {
+                        if (err) { return done(err); }
+                        value.should.be.equal("test");
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should store property - creates parent properties', function (done) {
+            context.set("nodeX", "foo.bar", "test", function (err) {
+                context.get("nodeX", "foo", function (err, value) {
+                    value.should.be.eql({ bar: "test" });
+                    done();
+                });
+            });
+        });
+
+        it('should store local scope property', function (done) {
+            context.set("abc:def", "foo.bar", "test", function (err) {
+                context.get("abc:def", "foo", function (err, value) {
+                    value.should.be.eql({ bar: "test" });
+                    done();
+                });
+            });
+        });
+
+        it('should delete property', function (done) {
+            context.set("nodeX", "foo.abc.bar1", "test1", function (err) {
+                context.set("nodeX", "foo.abc.bar2", "test2", function (err) {
+                    context.get("nodeX", "foo.abc", function (err, value) {
+                        value.should.be.eql({ bar1: "test1", bar2: "test2" });
+                        context.set("nodeX", "foo.abc.bar1", undefined, function (err) {
+                            context.get("nodeX", "foo.abc", function (err, value) {
+                                value.should.be.eql({ bar2: "test2" });
+                                context.set("nodeX", "foo.abc", undefined, function (err) {
+                                    context.get("nodeX", "foo.abc", function (err, value) {
+                                        should.not.exist(value);
+                                        context.set("nodeX", "foo", undefined, function (err) {
+                                            context.get("nodeX", "foo", function (err, value) {
+                                                should.not.exist(value);
+                                                done();
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should do nothing if try to delete non-existent value', function (done) {
+            context.set("nodeX", "foo.abc", { bar1: "test1", bar2: "test2", arr: ["test1", "test2"] }, function (err) {
+                context.set("nodeX", ["foo.non", "foo.abc.bar3", "foo.abc[2]"],[undefined, undefined, undefined], function (err) {
+                    context.get("nodeX", "foo.abc", function (err, value) {
+                        value.should.be.eql({ bar1: "test1", bar2: "test2", arr: ["test1", "test2"] });
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should not shared context with other scope', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.get("nodeY", "foo", function (err, value) {
+                    should.not.exist(value);
+                    context.set("nodeX", "foo", "testX", function (err) {
+                        context.set("nodeY", "foo", "testY", function (err) {
+                            context.get("nodeX", "foo", function (err, value) {
+                                value.should.be.equal("testX");
+                                context.get("nodeY", "foo", function (err, value) {
+                                    value.should.be.equal("testY");
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should store a string', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", "bar", function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        value.should.be.String();
+                        value.should.be.equal("bar");
+                        context.set("nodeX", "foo", "1", function (err) {
+                            context.get("nodeX", "foo", function (err, value) {
+                                value.should.be.String();
+                                value.should.be.equal("1");
+                                done();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should store a number', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", 1, function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        value.should.be.Number();
+                        value.should.be.equal(1);
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should store a null', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", null, function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        should(value).be.null();
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should store a boolean', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", true, function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        value.should.be.Boolean().and.true();
+                        context.set("nodeX", "foo", false, function (err) {
+                            context.get("nodeX", "foo", function (err, value) {
+                                value.should.be.Boolean().and.false();
+                                done();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should store an object', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", { obj: "bar" }, function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        value.should.be.Object();
+                        value.should.eql({ obj: "bar" });
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should store an array', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", ["a", "b", "c"], function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        value.should.be.Array();
+                        value.should.eql(["a", "b", "c"]);
+                        context.get("nodeX", "foo[1]", function (err, value) {
+                            value.should.be.String();
+                            value.should.equal("b");
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should store an array of arrays', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", [["a", "b", "c"], [1, 2, 3, 4], [true, false]], function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        value.should.be.Array();
+                        value.should.have.length(3);
+                        value[0].should.have.length(3);
+                        value[1].should.have.length(4);
+                        value[2].should.have.length(2);
+                        context.get("nodeX", "foo[1]", function (err, value) {
+                            value.should.be.Array();
+                            value.should.have.length(4);
+                            value.should.be.eql([1, 2, 3, 4]);
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should store an array of objects', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", [{ obj: "bar1" }, { obj: "bar2" }, { obj: "bar3" }], function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        value.should.be.Array();
+                        value.should.have.length(3);
+                        value[0].should.be.Object();
+                        value[1].should.be.Object();
+                        value[2].should.be.Object();
+                        context.get("nodeX", "foo[1]", function (err, value) {
+                            value.should.be.Object();
+                            value.should.be.eql({ obj: "bar2" });
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should handle a circular object', function (done) {
+            const foo = { bar: 'baz' };
+            foo.foo = foo;
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.set("nodeX", "foo", foo, function (err) {
+                    context.get("nodeX", "foo", function (err, value) {
+                        should.not.exist(value.foo);
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should set/get multiple values', function (done) {
+            context.set("nodeX", ["one", "two", "three"], ["test1", "test2", "test3"], function (err) {
+                context.get("nodeX", ["one", "two"], function () {
+                    Array.prototype.slice.apply(arguments).should.eql([null, "test1", "test2"]);
+                    context.set("nodeX", ["foo", "foo", "foo", "foo"], ["bar", undefined, "baz", undefined], function (err) {
+                        context.get("nodeX", "foo", function (err, value) {
+                            should.not.exist(value);
+                            context.set("nodeX", ["foo", "foo.bar", "foo", "foo.bar"], [{bar:"baz"}, undefined, undefined, "baz"], function (err) {
+                                context.get("nodeX", "foo", function (err, value) {
+                                    value.should.eql({bar:"baz"});
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+        it('should set/get multiple values - get unknown', function (done) {
+            context.set("nodeX", ["one", "two", "three"], ["test1", "test2", "test3"], function (err) {
+                context.get("nodeX", ["one", "two", "unknown"], function () {
+                    Array.prototype.slice.apply(arguments).should.eql([null, "test1", "test2", undefined]);
+                    done();
+                });
+            });
+        });
+        it('should set/get multiple values - single value provided', function (done) {
+            context.set("nodeX", ["one", "two", "three"], "test1", function (err) {
+                context.get("nodeX", ["one", "two"], function () {
+                    Array.prototype.slice.apply(arguments).should.eql([null, "test1", null]);
+                    done();
+                });
+            });
+        });
+
+        it('should throw error if bad key included in multiple keys - get', function (done) {
+            context.set("nodeX", ["one", "two", "three"], ["test1", "test2", "test3"], function (err) {
+                context.get("nodeX", ["one", ".foo", "three"], function (err) {
+                    should.exist(err);
+                    done();
+                });
+            });
+        });
+
+        it('should throw error if bad key included in multiple keys - set', function (done) {
+            context.set("nodeX", ["one", ".foo", "three"], ["test1", "test2", "test3"], function (err) {
+                should.exist(err);
+                // Check 'one' didn't get set as a result
+                context.get("nodeX", "one", function (err, one) {
+                    should.not.exist(one);
+                    done();
+                });
+            });
+        });
+
+        it('should throw an error when getting a value with invalid key', function (done) {
+            context.set("nodeX", "foo", "bar", function (err) {
+                context.get("nodeX", " ", function (err, value) {
+                    should.exist(err);
+                    done();
+                });
+            });
+        });
+
+        it('should throw an error when setting a value with invalid key', function (done) {
+            context.set("nodeX", " ", "bar", function (err) {
+                should.exist(err);
+                done();
+            });
+        });
+
+        it('should throw an error when callback of get() is not a function', function (done) {
+            try {
+                context.get("nodeX", "foo", "callback");
+                done("should throw an error.");
+            } catch (err) {
+                done();
+            }
+        });
+
+        it('should throw an error when callback of get() is not specified', function (done) {
+            try {
+                context.get("nodeX", "foo");
+                done("should throw an error.");
+            } catch (err) {
+                done();
+            }
+        });
+
+        it('should throw an error when callback of set() is not a function', function (done) {
+            try {
+                context.set("nodeX", "foo", "bar", "callback");
+                done("should throw an error.");
+            } catch (err) {
+                done();
+            }
+        });
+
+        it('should not throw an error when callback of set() is not specified', function (done) {
+            try {
+                context.set("nodeX", "foo", "bar");
+                done();
+            } catch (err) {
+                done("should not throw an error.");
+            }
+        });
+    });
+
+    describe('#keys', function () {
+        const prefix = util.generateId();
+        const context = redisPlugin({ prefix: prefix });
+
+        before(function () {
+            return context.open();
+        });
+        afterEach(function () {
+            return context.delete("*").then(() => context.clean([]));
+        });
+        after(function () {
+            return context.close();
+        });
+
+        it('should enumerate context keys', function (done) {
+            context.keys("nodeX", function (err, value) {
+                value.should.be.an.Array();
+                value.should.be.empty();
+                context.set("nodeX", "foo", "bar", function (err) {
+                    context.keys("nodeX", function (err, value) {
+                        value.should.have.length(1);
+                        value[0].should.equal("foo");
+                        context.set("nodeX", "abc.def", "bar", function (err) {
+                            context.keys("nodeX", function (err, value) {
+                                value.should.have.length(2);
+                                value.should.containDeep(["foo", "abc"]);
+                                done();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should enumerate context keys in each scopes', function (done) {
+            context.keys("nodeX", function (err, value) {
+                value.should.be.an.Array();
+                value.should.be.empty();
+                context.keys("nodeY", function (err, value) {
+                    value.should.be.an.Array();
+                    value.should.be.empty();
+                    context.set("nodeX", "foo", "bar", function (err) {
+                        context.set("nodeY", "hoge", "piyo", function (err) {
+                            context.keys("nodeX", function (err, value) {
+                                value.should.have.length(1);
+                                value[0].should.equal("foo");
+                                context.keys("nodeY", function (err, value) {
+                                    value.should.have.length(1);
+                                    value[0].should.equal("hoge");
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should throw an error when callback of keys() is not a function', function (done) {
+            try {
+                context.keys("nodeX", "callback");
+                done("should throw an error.");
+            } catch (err) {
+                done();
+            }
+        });
+
+        it('should throw an error when callback of keys() is not specified', function (done) {
+            try {
+                context.keys("nodeX");
+                done("should throw an error.");
+            } catch (err) {
+                done();
+            }
+        });
+    });
+
+    describe('#delete', function () {
+        const prefix = util.generateId();
+        const context = redisPlugin({ prefix: prefix });
+
+        before(function () {
+            return context.open();
+        });
+        afterEach(function () {
+            return context.delete("*").then(() => context.clean([]));
+        });
+        after(function () {
+            return context.close();
+        });
+        it('should delete context', function (done) {
+            context.get("nodeX", "foo", function (err, value) {
+                should.not.exist(value);
+                context.get("nodeY", "foo", function (err, value) {
+                    should.not.exist(value);
+                    context.set("nodeX", "foo", "testX", function (err) {
+                        context.set("nodeY", "foo", "testY", function (err) {
+                            context.get("nodeX", "foo", function (err, value) {
+                                value.should.be.equal("testX");
+                                context.get("nodeY", "foo", function (err, value) {
+                                    value.should.be.equal("testY");
+                                    context.delete("nodeX").then(function () {
+                                        context.get("nodeX", "foo", function (err, value) {
+                                            should.not.exist(value);
+                                            context.get("nodeY", "foo", function (err, value) {
+                                                value.should.be.equal("testY");
+                                                done();
+                                            });
+                                        });
+                                    }).catch(done);
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe.skip('#clean', function () {
+        const prefix = util.generateId();
+        const context = redisPlugin({ prefix: prefix });
+        function redisGet(scope, key) {
+            return new Promise((res, rej) => {
+                context.get(scope, key, function (err, value) {
+                    if (err) {
+                        rej(err);
+                    } else {
+                        res(value);
+                    }
+                });
+            });
+        }
+        function redisSet(scope, key, value) {
+            return new Promise((res, rej) => {
+                context.set(scope, key, value, function (err) {
+                    if (err) {
+                        rej(err);
+                    } else {
+                        res();
+                    }
+                });
+            });
+        }
+        before(function () {
+            return context.open();
+        });
+        afterEach(function () {
+            return context.clean([]);
+        });
+        after(function () {
+            return context.close();
+        });
+
+        it('should not clean active context', function () {
+            return redisSet("global", "foo", "testGlobal").then(function () {
+                return redisSet("nodeX:flow1", "foo", "testX");
+            }).then(function () {
+                return redisSet("nodeY:flow2", "foo", "testY");
+            }).then(function () {
+                return redisGet("nodeX:flow1", "foo").should.be.fulfilledWith("testX");
+            }).then(function () {
+                return redisGet("nodeY:flow2", "foo").should.be.fulfilledWith("testY");
+            }).then(function () {
+                return context.clean(["flow1", "nodeX"]);
+            }).then(function () {
+                return redisGet("nodeX:flow1", "foo").should.be.fulfilledWith("testX");
+            }).then(function () {
+                return redisGet("nodeY:flow2", "foo").should.be.fulfilledWith(undefined);
+            }).then(function () {
+                return redisGet("global", "foo").should.be.fulfilledWith("testGlobal");
+            });
+        });
+
+        it('should clean unnecessary context', function () {
+            return redisSet("global", "foo", "testGlobal").then(function () {
+                return redisSet("nodeX:flow1", "foo", "testX");
+            }).then(function () {
+                return redisSet("nodeY:flow2", "foo", "testY");
+            }).then(function () {
+                return redisGet("nodeX:flow1", "foo").should.be.fulfilledWith("testX");
+            }).then(function () {
+                return redisGet("nodeY:flow2", "foo").should.be.fulfilledWith("testY");
+            }).then(function () {
+                return context.clean([]);
+            }).then(function () {
+                return redisGet("nodeX:flow1", "foo").should.be.fulfilledWith(undefined);
+            }).then(function () {
+                return redisGet("nodeY:flow2", "foo").should.be.fulfilledWith(undefined);
+            }).then(function () {
+                return redisGet("global", "foo").should.be.fulfilledWith("testGlobal");
+            });
+        });
+    });
+});


### PR DESCRIPTION
This makes it possible to store context data to Redis.

The design note is https://github.com/node-red/node-red/wiki/Design%3A-Persistable-Context#redis-plugin.

#### Install prototype

1. Run the following command
```
cd ~/.node-red
npm install git+https://github.com/node-red-hitachi/node-red-context-redis
```

2. Add a configuration in settings.js
```javascrip
contextStorage: {
    redis: {
        module: require("node-red-context-redis"),
        config: {
            // see Readme.md
        }
    }
}
```

I would appreciate if you could give me feedback  on design, codes, following concerns, etc.

#### Concerns

* How to clean unnecessary context ?
`clean` function detects and removes unnecessary contexts based on `activeNodes` argument and data in the store.
But when there are some data stored by others in the store, the plugin cannot determine if the data is not used.

  Options:
  1. Clean the data without caring others.
  The plugin cleans the data according to its `activeNodes` only. But others data are also deleted.
  `memory` and `localfilesystem` do this  because their store are not shared with others.

  2. `clean` function receives `deactiveNodes` list instead of `activeNodes`.
  The plugin can know what is not used according to it, but we have to change codes. e.g. other plugin  `clean`.

  3. Don't clean.
  User has to clean manually if needed.
  This prototype does not clean the data.