### PR TITLE
Improve async store error when sync api used

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,6 @@
-***This is a work in progress.***
+# Redis Context store plugin
 
-# Redis plugin
-
-The Redis plugin holds context data in the Redis.
+The Redis Context store plugin holds context data in the Redis.
 
 ## Pre-requisite
 
@@ -40,8 +38,7 @@ It needs following configuration options:
 | prefix         | If set, the string used to prefix all used keys.                                                            |
 | password       | If set, the plugin will run Redis AUTH command on connect. *Note: the password will be sent as plaintext.*  |
 | tls            | An object containing options to pass to tls.connect to set up a TLS connection to the server.               |
-| retry_strategy | Specifies a function to reconnect if the connection to Redis is lost.                                       |
-|                | `default: undefined (Use the default retry strategy)`                                                       |
+| retry_strategy | Specifies a function to reconnect if the connection to Redis is lost.<br> `default: undefined (Use the default retry strategy)`|
 
 see https://github.com/NodeRedis/node_redis#options-object-properties
 

--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ Redis.prototype.close = function () {
 
 Redis.prototype.get = function (scope, key, callback) {
     if (typeof callback !== 'function') {
-        throw new Error('Callback must be a function');
+        throw new Error('Async storage - a callback must be defined');
     }
     try {
         if (!Array.isArray(key)) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Improved the error message when callback is not specified in get() to an appropriate message.

This is a fix for the same issue pointed out in the PouchDB Context store plugin.
https://github.com/node-red/node-red-context-pouchdb/pull/1#issuecomment-866750901

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
